### PR TITLE
fix(back): fix missing timeout error "case"

### DIFF
--- a/models/error.go
+++ b/models/error.go
@@ -49,7 +49,7 @@ func (e *MonitororError) Timeout() bool {
 	// Host unreachable
 	err := e.Err
 	for {
-		if x, ok := err.(*net.DNSError); ok && x.IsNotFound {
+		if _, ok := err.(*net.DNSError); ok {
 			return true
 		}
 


### PR DESCRIPTION
DNSError with IsNotFound=false is concidered as a timeout error
Ex: Wifi disconnected