### PR TITLE
Stripe implementation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,6 +192,7 @@ func InitConfig() *Config {
 		viper.SetDefault(fmt.Sprintf("Monitorable.Github.%s.InitialMaxDelay", variant), DefaultInitialMaxDelay)
 	}
 
+  // --- Stripe Configuration ---
 	for variant := range variants["Stripe"] {
 		viper.SetDefault(fmt.Sprintf("Monitorable.Stripe.%s.Token", variant), "")
 		viper.SetDefault(fmt.Sprintf("Monitorable.Stripe.%s.CountCacheExpiration", variant), 300000)

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type (
 		Jenkins     map[string]*Jenkins
 		AzureDevOps map[string]*AzureDevOps
 		Github      map[string]*Github
+		Stripe      map[string]*Stripe
 	}
 
 	Ping struct {
@@ -96,6 +97,12 @@ type (
 		Token                string
 		CountCacheExpiration int // In Millisecond
 		InitialMaxDelay      int // In Millisecond
+	}
+
+	Stripe struct {
+		Token                string // Secret API key
+		CountCacheExpiration int    // In Millisecond
+		InitialMaxDelay      int    // In Millisecond
 	}
 )
 
@@ -185,6 +192,12 @@ func InitConfig() *Config {
 		viper.SetDefault(fmt.Sprintf("Monitorable.Github.%s.InitialMaxDelay", variant), DefaultInitialMaxDelay)
 	}
 
+	for variant := range variants["Stripe"] {
+		viper.SetDefault(fmt.Sprintf("Monitorable.Stripe.%s.Token", variant), "")
+		viper.SetDefault(fmt.Sprintf("Monitorable.Stripe.%s.CountCacheExpiration", variant), 300000)
+		viper.SetDefault(fmt.Sprintf("Monitorable.Stripe.%s.InitialMaxDelay", variant), DefaultInitialMaxDelay)
+	}
+
 	_ = viper.Unmarshal(&config)
 
 	return &config
@@ -239,4 +252,8 @@ func (t *AzureDevOps) IsValid() bool {
 
 func (g *Github) IsValid() bool {
 	return g.Token != ""
+}
+
+func (s *Stripe) IsValid() bool {
+	return s.Token != ""
 }

--- a/config/config.go
+++ b/config/config.go
@@ -192,7 +192,7 @@ func InitConfig() *Config {
 		viper.SetDefault(fmt.Sprintf("Monitorable.Github.%s.InitialMaxDelay", variant), DefaultInitialMaxDelay)
 	}
 
-  // --- Stripe Configuration ---
+	// --- Stripe Configuration ---
 	for variant := range variants["Stripe"] {
 		viper.SetDefault(fmt.Sprintf("Monitorable.Stripe.%s.Token", variant), "")
 		viper.SetDefault(fmt.Sprintf("Monitorable.Stripe.%s.CountCacheExpiration", variant), 300000)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
+	github.com/stripe/stripe-go v70.3.0+incompatible
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,11 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stripe/stripe-go v1.0.3 h1:RHgK2FUKawVNBPJ15pNM4IWkEVVCg5Ju3xK5QZNhTwY=
+github.com/stripe/stripe-go v70.2.0+incompatible h1:bT2+4o5EBsC5Cx+t7lK2C90VCcXeznYGB/9cUz7MLZA=
+github.com/stripe/stripe-go v70.2.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
+github.com/stripe/stripe-go v70.3.0+incompatible h1:M1Ua0DevRTuMVc5+X90Vyyh8jD690dgZMHIilE9GGjQ=
+github.com/stripe/stripe-go v70.3.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/monitorable/stripe/delivery/handlers.go
+++ b/monitorable/stripe/delivery/handlers.go
@@ -1,0 +1,34 @@
+package delivery
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorable/stripe"
+	stripeModels "github.com/monitoror/monitoror/monitorable/stripe/models"
+)
+
+type StripeDelivery struct {
+	stripeUsecase stripe.Usecase
+}
+
+func NewStripeDelivery(u stripe.Usecase) *StripeDelivery {
+	return &StripeDelivery{u}
+}
+
+func (d *StripeDelivery) GetCount(c echo.Context) error {
+	// Bind / check Params
+	params := &stripeModels.CountParams{}
+	err := c.Bind(params)
+	if err != nil || !params.IsValid() {
+		return models.QueryParamsError
+	}
+
+	tile, err := d.stripeUsecase.Count(params)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, tile)
+}

--- a/monitorable/stripe/models/params.go
+++ b/monitorable/stripe/models/params.go
@@ -1,0 +1,11 @@
+package models
+
+type (
+	CountParams struct {
+		CreatedAfter string
+	}
+)
+
+func (p *CountParams) IsValid() bool {
+	return true
+}

--- a/monitorable/stripe/repository.go
+++ b/monitorable/stripe/repository.go
@@ -1,0 +1,7 @@
+package stripe
+
+type (
+	Repository interface {
+		GetCount(afterTimestamp string) (float64, int, error)
+	}
+)

--- a/monitorable/stripe/repository/api.go
+++ b/monitorable/stripe/repository/api.go
@@ -1,0 +1,56 @@
+package repository
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/monitoror/monitoror/config"
+	"github.com/stripe/stripe-go"
+	"github.com/stripe/stripe-go/client"
+)
+
+type (
+	stripeRepository struct {
+		stripeClient *client.API
+		config       *config.Stripe
+	}
+)
+
+// NewStripeRepository makes a new Stripe connection from an API key
+func NewStripeRepository(config *config.Stripe) *stripeRepository {
+	stripe.DefaultLeveledLogger = &stripe.LeveledLogger{Level: stripe.LevelError}
+	sc := &client.API{}
+	sc.Init(config.Token, nil)
+	return &stripeRepository{
+		stripeClient: sc,
+		config:       config,
+	}
+}
+
+func (r *stripeRepository) GetCount(afterTimestamp string) (float64, int, error) {
+	if afterTimestamp == "" || afterTimestamp == "today" {
+		afterTimestamp = strconv.FormatInt(bod(time.Now().Local()).Unix(), 10)
+	}
+	_, err := strconv.ParseUint(afterTimestamp, 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	params := &stripe.BalanceTransactionListParams{}
+	params.Filters.AddFilter("type", "", "charge")
+	params.Filters.AddFilter("created", "gte", afterTimestamp)
+	params.Filters.AddFilter("limit", "", "100")
+	result := r.stripeClient.BalanceTransaction.List(params)
+	count := 0
+	net := 0.0
+	for result.Next() {
+		net = net + float64(result.BalanceTransaction().Net)
+		count = count + 1
+	}
+	net = net / 100
+	return net, count, nil
+}
+
+func bod(t time.Time) time.Time {
+	year, month, day := t.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, t.Location())
+}

--- a/monitorable/stripe/repository/api.go
+++ b/monitorable/stripe/repository/api.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/monitoror/monitoror/config"
+	stripeLocal "github.com/monitoror/monitoror/monitorable/stripe"
 	"github.com/stripe/stripe-go"
 	"github.com/stripe/stripe-go/client"
 )
@@ -17,7 +18,7 @@ type (
 )
 
 // NewStripeRepository makes a new Stripe connection from an API key
-func NewStripeRepository(config *config.Stripe) *stripeRepository {
+func NewStripeRepository(config *config.Stripe) stripeLocal.Repository {
 	stripe.DefaultLeveledLogger = &stripe.LeveledLogger{Level: stripe.LevelError}
 	sc := &client.API{}
 	sc.Init(config.Token, nil)

--- a/monitorable/stripe/usecase.go
+++ b/monitorable/stripe/usecase.go
@@ -1,0 +1,16 @@
+package stripe
+
+import (
+	"github.com/monitoror/monitoror/models"
+	stripeModels "github.com/monitoror/monitoror/monitorable/stripe/models"
+)
+
+const (
+	StripeCountTileType models.TileType = "STRIPE-COUNT"
+)
+
+type (
+	Usecase interface {
+		Count(params *stripeModels.CountParams) (*models.Tile, error)
+	}
+)

--- a/monitorable/stripe/usecase/stripe.go
+++ b/monitorable/stripe/usecase/stripe.go
@@ -1,0 +1,41 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorable/stripe"
+	stripeModels "github.com/monitoror/monitoror/monitorable/stripe/models"
+	"github.com/monitoror/monitoror/pkg/monitoror/cache"
+)
+
+const buildCacheSize = 5
+
+type (
+	stripeUsecase struct {
+		repository stripe.Repository
+
+		// builds cache. used for save small history of build for stats
+		buildsCache *cache.BuildCache
+	}
+)
+
+func NewStripeUsecase(repository stripe.Repository) stripe.Usecase {
+	return &stripeUsecase{
+		repository,
+		cache.NewBuildCache(buildCacheSize),
+	}
+}
+
+func (su *stripeUsecase) Count(params *stripeModels.CountParams) (*models.Tile, error) {
+	tile := models.NewTile(stripe.StripeCountTileType).WithValue(models.RawUnit)
+	tile.Label = "Stripe Count"
+
+	net, count, err := su.repository.GetCount(params.CreatedAfter)
+	if err != nil {
+		return nil, &models.MonitororError{Err: err, Tile: tile, Message: "timestamp has invalid format"}
+	}
+	tile.Status = models.SuccessStatus
+	tile.Value.Values = append(tile.Value.Values, fmt.Sprintf("$%.2f (%d)", net, count))
+	return tile, nil
+}

--- a/ui/src/components/TileIcon.vue
+++ b/ui/src/components/TileIcon.vue
@@ -50,6 +50,27 @@
     <svg v-else-if="isAzure" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
       <path d="M193.412 58.029l62.586-11.421v157.685l.005.001-62.588 51.604-.004-.001-.001.001v-.001l-96.473-32.233V256L25.94 172.124l167.47 23.417V58.03L25.938 89.904v82.22L0 167.306V94.841l25.938-33.88 87.979-34.394V0l79.495 58.029z" fill-rule="nonzero"/>
     </svg>
+
+    <svg v-else-if="isStripe" version="1.1"
+      id="svg5512" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg"
+      xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 362 151.8"
+      style="enable-background:new 0 0 362 151.8;" xml:space="preserve">
+      <path id="path5516" inkscape:connector-curvature="0" class="st0" d="M361,78.4c0-25.6-12.4-45.8-36.1-45.8
+        c-23.8,0-38.2,20.2-38.2,45.6c0,30.1,17,45.3,41.4,45.3c11.9,0,20.9-2.7,27.7-6.5V97c-6.8,3.4-14.6,5.5-24.5,5.5
+        c-9.7,0-18.3-3.4-19.4-15.2h48.9C360.8,86,361,80.8,361,78.4z M311.6,68.9c0-11.3,6.9-16,13.2-16c6.1,0,12.6,4.7,12.6,16H311.6z"/>
+      <path id="path5518" inkscape:connector-curvature="0" class="st0" d="M248.1,32.6c-9.8,0-16.1,4.6-19.6,7.8l-1.3-6.2h-22v116.6
+        l25-5.3l0.1-28.3c3.6,2.6,8.9,6.3,17.7,6.3c17.9,0,34.2-14.4,34.2-46.1C282.1,48.4,265.6,32.6,248.1,32.6L248.1,32.6z M242.1,101.5
+        c-5.9,0-9.4-2.1-11.8-4.7l-0.1-37.1c2.6-2.9,6.2-4.9,11.9-4.9c9.1,0,15.4,10.2,15.4,23.3C257.5,91.5,251.3,101.5,242.1,101.5z"/>
+      <polygon id="polygon5520" class="st0" points="195.9,21.3 195.9,1 170.8,6.3 170.8,26.7 "/>
+      <rect id="rect5522" x="170.8" y="34.3" class="st0" width="25.1" height="87.5"/>
+      <path id="path5524" inkscape:connector-curvature="0" class="st0" d="M143.9,41.7l-1.6-7.4h-21.6v87.5h25V62.5
+        c5.9-7.7,15.9-6.3,19-5.2v-23C161.5,33.1,149.8,30.9,143.9,41.7L143.9,41.7z"/>
+      <path id="path5526" inkscape:connector-curvature="0" class="st0" d="M93.9,12.6l-24.4,5.2l-0.1,80.1c0,14.8,11.1,25.7,25.9,25.7
+        c8.2,0,14.2-1.5,17.5-3.3V100c-3.2,1.3-19,5.9-19-8.9V55.6h19V34.3h-19L93.9,12.6z"/>
+      <path id="path5528" inkscape:connector-curvature="0" class="st0" d="M26.3,59.7c0-3.9,3.2-5.4,8.5-5.4c7.6,0,17.2,2.3,24.8,6.4
+        V37.2c-8.3-3.3-16.5-4.6-24.8-4.6C14.5,32.6,1,43.2,1,60.9C1,88.5,39,84.1,39,96c0,4.6-4,6.1-9.6,6.1c-8.3,0-18.9-3.4-27.3-8v23.8
+        c9.3,4,18.7,5.7,27.3,5.7c20.8,0,35.1-10.3,35.1-28.2C64.4,65.6,26.3,70.9,26.3,59.7L26.3,59.7z"/>
+    </svg>
   </div>
 </template>
 
@@ -120,6 +141,10 @@
         TileType.AzureDevOpsBuild,
         TileType.AzureDevOpsRelease,
       ].includes(this.tileType)
+    }
+
+    get isStripe(): boolean {
+      return this.tileType === TileType.StripeCount
     }
   }
 </script>

--- a/ui/src/enums/tileType.ts
+++ b/ui/src/enums/tileType.ts
@@ -12,6 +12,7 @@ export enum TileType {
   Jenkins = 'JENKINS-BUILD',
   AzureDevOpsBuild = 'AZUREDEVOPS-BUILD',
   AzureDevOpsRelease = 'AZUREDEVOPS-RELEASE',
+  StripeCount = 'STRIPE-COUNT',
 
   Empty = 'EMPTY',
   Group = 'GROUP',


### PR DESCRIPTION
Stripe implementation that counts how many charges were made from a timestamp until now.

![image](https://user-images.githubusercontent.com/31434093/76671463-bf09c180-6553-11ea-8b41-13791a8a6853.png)

Config: 
```json
       {
            "type": "STRIPE-COUNT",
            "label": "Sales Today",
            "params": {
                "createdAfter": "today"
            }
        }
```
`createdAfter` is either unix timestamp or `today`