### PR TITLE
Add line graph support for series data

### DIFF
--- a/models/tilevalue.go
+++ b/models/tilevalue.go
@@ -14,6 +14,7 @@ const (
 	RatioUnit       TileValuesUnit = "RATIO"       // Ratio like 0.8465896
 	NumberUnit      TileValuesUnit = "NUMBER"      // Number in float
 	RawUnit         TileValuesUnit = "RAW"         // String
+	TrendUnit       TileValuesUnit = "TREND"       // Array of timeseries data to draw trend
 )
 
 func (t *Tile) WithValue(unit TileValuesUnit) *Tile {

--- a/ui/node_modules/@types/vuetrend.d.ts
+++ b/ui/node_modules/@types/vuetrend.d.ts
@@ -1,0 +1,1 @@
+declare module 'vuetrend';

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.2",
     "vue-property-decorator": "^8.3.0",
+    "vuetrend": "^0.3.4",
     "vuex": "^3.1.2"
   },
   "devDependencies": {

--- a/ui/src/components/Tile.vue
+++ b/ui/src/components/Tile.vue
@@ -1,6 +1,14 @@
 <template>
   <div class="c-monitoror-tile" :class="classes" :style="styles">
     <div class="c-monitoror-tile--content" v-if="!isEmpty">
+      <trend class="c-monitoror-tile--trend" v-if="isTrend"
+        :data="trendData"
+        :gradient="['#666666', '#000000']"
+        smooth
+        auto-draw
+      >
+      </trend>
+
       <div class="c-monitoror-tile--label">
         {{ label }}
       </div>
@@ -112,6 +120,10 @@
       return styles
     }
 
+    get isTrend(): boolean {
+      return this.unit === TileValueUnit.Trend
+    }
+
     get isEmpty(): boolean {
       return this.type === TileType.Empty
     }
@@ -184,6 +196,13 @@
       return this.value.values
     }
 
+    get trendData(): number[] {
+      if (this.values === undefined || this.unit !== TileValueUnit.Trend) {
+        return []
+      }
+      return JSON.parse(this.values[this.values.length - 1])
+    }
+
     get displayedValue(): string | undefined {
       if (this.values === undefined) {
         return
@@ -194,6 +213,7 @@
         [TileValueUnit.Ratio]: '%',
         [TileValueUnit.Number]: '',
         [TileValueUnit.Raw]: '',
+        [TileValueUnit.Trend]: '',
       }
 
       let value = this.values[this.values.length - 1]
@@ -201,6 +221,13 @@
         value = Math.round(parseFloat(value)).toString()
       } else if (this.unit === TileValueUnit.Ratio) {
         value = (parseFloat(value) * 100).toFixed(2).toString()
+      } else if (this.unit === TileValueUnit.Trend) {
+        const dataArr: number[] = JSON.parse(value)
+        if (dataArr.length >= 1) {
+          value = dataArr[dataArr.length - 1].toFixed(2).toString()
+        } else {
+          value = 'No data'
+        }
       }
 
       return value + UNIT_DISPLAY[this.unit]
@@ -267,6 +294,17 @@
     @media screen and (max-width: 750px) {
       min-height: 160px;
     }
+  }
+
+  .c-monitoror-tile--trend {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+    stroke-width: 5px;
+    stroke-linecap: round;
+    stroke-opacity: 20%;
   }
 
   .c-monitoror-tile--label {

--- a/ui/src/enums/tileValueUnit.ts
+++ b/ui/src/enums/tileValueUnit.ts
@@ -3,6 +3,7 @@ enum TileValueUnit {
   Ratio = 'RATIO',
   Number = 'NUMBER',
   Raw = 'RAW',
+  Trend = 'TREND',
 }
 
 export default TileValueUnit

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -22,7 +22,9 @@ import Info from '@/interfaces/info'
 import TaskOptions from '@/interfaces/taskOptions'
 import TileConfig from '@/interfaces/tileConfig'
 import TileState from '@/interfaces/tileState'
+import Trend from 'vuetrend'
 
+Vue.use(Trend)
 Vue.use(Vuex)
 
 const API_BASE_PATH = '/api/v1'

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -3,7 +3,7 @@ module.exports = {
     port: '8000',
     proxy: {
       '^/api': {
-        target: 'http://localhost:8888',
+        target: 'http://localhost:8080',
       },
     },
   },

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -3,7 +3,7 @@ module.exports = {
     port: '8000',
     proxy: {
       '^/api': {
-        target: 'http://localhost:8080',
+        target: 'http://localhost:8888',
       },
     },
   },

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11225,6 +11225,11 @@ vue@^2.6.11:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
 
+vuetrend@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/vuetrend/-/vuetrend-0.3.4.tgz#35e1dafb0f7cf4d66f69e289ee7028b9e12783d9"
+  integrity sha512-UaOJhMnkoiRBlGB9k2FX5GqotJyoyYUpyTAjfBiB7K5ESt3KzRoaplfG7j7SAnH4ITk4DjVDC9WB2IX80TVYmQ==
+
 vuex@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.1.2.tgz#a2863f4005aa73f2587e55c3fadf3f01f69c7d4d"


### PR DESCRIPTION
Add ability to draw graph for data array. Pass JSON array as string to front end and it draw a graph. The number in the center is the last value in the array. Add `TREND` tile value unit for graphing data.

![image](https://user-images.githubusercontent.com/31434093/77021520-21900280-6944-11ea-9464-c92a3067aeb2.png)
