### PR TITLE
Refactor GitHub pullrequests

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -87,7 +87,8 @@
             <ul>
               <li><a href="#tile-github-count">GITHUB-COUNT</a></li>
               <li><a href="#tile-github-checks">GITHUB-CHECKS</a></li>
-              <li><a href="#tile-generate-github-checks">GENERATE:GITHUB-CHECKS</a></li>
+              <li><a href="#tile-github-pullrequest">GITHUB-PULLREQUEST</a></li>
+              <li><a href="#tile-generate-github-pullrequest">GENERATE:GITHUB-PULLREQUEST</a></li>
             </ul>
           </li>
           <li><a href="#http">HTTP</a>
@@ -879,7 +880,7 @@ chmod +x monitoror
       <h3 id="github">GitHub</h3>
 
       <p>
-        Show branch checks status and display search result counters.
+        Show branch or pull request checks status and display search result counters.
       </p>
 
       <h5 class="m-documentation--configuration-side-title">Core configuration</h5>
@@ -991,7 +992,7 @@ chmod +x monitoror
       <h4 id="tile-github-checks">GITHUB-CHECKS</h4>
 
       <p>
-        Show the status of all checks for a given commit reference.
+        Show the status of all checks for a given git reference.
       </p>
 
       <h5 class="m-documentation--configuration-side-title">UI configuration</h5>
@@ -1052,22 +1053,101 @@ chmod +x monitoror
           </div>
           <div class="m-documentation--demo-switch">
             <label class="m-documentation--demo-switch-label m-documentation--demo-switch-running">
-              <input data-state-switch name="github-release-state" type="radio" value="running">
+              <input data-state-switch name="github-checks-state" type="radio" value="running">
               Running
             </label>
             <label class="m-documentation--demo-switch-label m-documentation--demo-switch-warning">
-              <input data-state-switch name="azuredevops-release-state" type="radio" value="warning">
+              <input data-state-switch name="github-checks-state" type="radio" value="warning">
               Warning
             </label>
             <label class="m-documentation--demo-switch-label m-documentation--demo-switch-error">
-              <input data-state-switch name="azuredevops-release-state" type="radio" value="error">
+              <input data-state-switch name="github-checks-state" type="radio" value="error">
               Error
             </label>
           </div>
         </div>
       </div>
 
-      <h4 id="tile-generate-github-checks">GENERATE:GITHUB-CHECKS</h4>
+      <h4 id="tile-github-pullrequest">GITHUB-PULLREQUEST</h4>
+
+      <p>
+        Show the status of all checks for a given pull request.
+      </p>
+
+      <h5 class="m-documentation--configuration-side-title">UI configuration</h5>
+
+      <dl>
+        <dt><code>owner</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>
+          GitHub group or user (from URL)
+        </dd>
+
+        <dt><code>repository</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>
+          GitHub repository name (from URL)
+        </dd>
+
+        <dt><code>id</code> <code class="type">number</code> <span class="required">required</span></dt>
+        <dd>
+          GitHub pull request ID <br>
+        </dd>
+      </dl>
+
+      <div class="m-documentation--example-and-demo">
+        <pre class="example"><code class="language-json">
+{
+  "type": "GITHUB-PULLREQUEST",
+  "params": {
+    "owner": "monitoror",
+    "repository": "monitoror",
+    "id": 10
+  }
+}
+        </code></pre>
+
+        <div class="m-documentation--demo">
+          <div class="m-documentation--demo-tile">
+            <div class="m-documentation--demo-label">PR#10 @ monitoror</div>
+            <svg class="m-documentation--demo-icon" fill="currentColor" viewBox="0 0 33 33"
+                 style="transform: translateY(2px)" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M16.288 0C7.293 0 0 7.293 0 16.29c0 7.197 4.667 13.302 11.14 15.457.815.149 1.112-.354 1.112-.786 0-.386-.014-1.411-.022-2.77-4.531.984-5.487-2.184-5.487-2.184-.741-1.881-1.809-2.382-1.809-2.382-1.479-1.011.112-.991.112-.991 1.635.116 2.495 1.679 2.495 1.679 1.453 2.489 3.813 1.77 4.741 1.354.148-1.053.568-1.771 1.034-2.178-3.617-.411-7.42-1.809-7.42-8.051 0-1.778.635-3.232 1.677-4.371-.168-.412-.727-2.068.159-4.311 0 0 1.368-.438 4.48 1.67a15.602 15.602 0 014.078-.548c1.383.006 2.777.187 4.078.548 3.11-2.108 4.475-1.67 4.475-1.67.889 2.243.33 3.899.162 4.311 1.044 1.139 1.675 2.593 1.675 4.371 0 6.258-3.809 7.635-7.438 8.038.585.503 1.106 1.497 1.106 3.017 0 2.177-.02 3.934-.02 4.468 0 .436.293.943 1.12.784 6.468-2.159 11.131-8.26 11.131-15.455C32.579 7.293 25.285 0 16.288 0"/>
+            </svg>
+            <div class="m-documentation--demo-message" data-status-running>
+              0:42
+            </div>
+            <div class="m-documentation--demo-message" data-status-warning>
+              5 minutes ago
+            </div>
+            <div class="m-documentation--demo-message" data-status-error>
+              5 minutes ago
+            </div>
+            <div class="m-documentation--demo-author" data-status-error>
+              <img alt="" class="m-documentation--demo-author-avatar" src="../assets/images/avatar.png">
+              John Doe
+            </div>
+            <div class="m-documentation--demo-progress" data-status-running>
+              <div class="m-documentation--demo-progress-bar"></div>
+            </div>
+          </div>
+          <div class="m-documentation--demo-switch">
+            <label class="m-documentation--demo-switch-label m-documentation--demo-switch-running">
+              <input data-state-switch name="github-pullrequest-state" type="radio" value="running">
+              Running
+            </label>
+            <label class="m-documentation--demo-switch-label m-documentation--demo-switch-warning">
+              <input data-state-switch name="github-pullrequest-state" type="radio" value="warning">
+              Warning
+            </label>
+            <label class="m-documentation--demo-switch-label m-documentation--demo-switch-error">
+              <input data-state-switch name="github-pullrequest-state" type="radio" value="error">
+              Error
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <h4 id="tile-generate-github-pullrequest">GENERATE:GITHUB-PULLREQUEST</h4>
 
       <p>
         Show each open pull request status.
@@ -1076,7 +1156,7 @@ chmod +x monitoror
       <p class="note">
         <span class="tag">Note</span>
         This tile is a generator tile that will be replaced by N classic
-        <code><a href="#tile-github-checks">GITHUB-CHECKS</a></code> tiles. <br>
+        <code><a href="#tile-github-checks">GITHUB-PULLREQUEST</a></code> tiles. <br>
         N being the number of open pull requests.
       </p>
 
@@ -1097,7 +1177,7 @@ chmod +x monitoror
       <div class="m-documentation--example">
         <pre class="example"><code class="language-json">
 {
-  "type": "GENERATE:GITHUB-CHECKS",
+  "type": "GENERATE:GITHUB-PULLREQUEST",
   "params": {
     "owner": "monitoror",
     "repository": "monitoror"

--- a/faker-configs/faker-build-config.json
+++ b/faker-configs/faker-build-config.json
@@ -28,6 +28,7 @@
     { "type": "AZUREDEVOPS-RELEASE", "params": { "project": "monitoror", "definition": 423, "status": "RUNNING" } },
     { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "master" } },
     { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "master", "status": "ACTION_REQUIRED" } },
-    { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "master", "status": "RUNNING" } }
+    { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "master", "status": "RUNNING" } },
+    { "type": "GITHUB-PULLREQUEST", "params": { "owner": "monitoror", "repository": "monitoror", "id": 1337, "branch": "fork:feature-branch", "status": "SUCCESS" } }
   ]
 }

--- a/faker-configs/faker-build-config.json
+++ b/faker-configs/faker-build-config.json
@@ -29,6 +29,13 @@
     { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "master" } },
     { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "master", "status": "ACTION_REQUIRED" } },
     { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "master", "status": "RUNNING" } },
-    { "type": "GITHUB-PULLREQUEST", "params": { "owner": "monitoror", "repository": "monitoror", "id": 1337, "branch": "fork:feature-branch", "status": "SUCCESS" } }
+    { "type": "GITHUB-PULLREQUEST", "label": "-", "params": { "owner": "monitoror", "repository": "monitoror", "id": 1337, "mergeRequestTitle": "Feature branch which adds a super new thing", "branch": "fork:feature-branch", "status": "SUCCESS" } },
+    {
+      "type": "GROUP",
+      "label": "Merge requests in group",
+      "tiles": [
+        { "type": "GITHUB-PULLREQUEST", "params": { "owner": "monitoror", "repository": "monitoror", "id": 42, "branch": "fork:fix-branch", "status": "RUNNING" } }
+      ]
+    }
   ]
 }

--- a/models/tilebuild.go
+++ b/models/tilebuild.go
@@ -6,14 +6,20 @@ type (
 	TileBuild struct {
 		PreviousStatus TileStatus `json:"previousStatus,omitempty"`
 
-		ID     *string `json:"id,omitempty"`
-		Branch *string `json:"branch,omitempty"`
-		Author *Author `json:"author,omitempty"`
+		ID           *string           `json:"id,omitempty"`
+		Branch       *string           `json:"branch,omitempty"`
+		MergeRequest *TileMergeRequest `json:"mergeRequest,omitempty"`
+		Author       *Author           `json:"author,omitempty"`
 
 		Duration          *int64     `json:"duration,omitempty"`          // In Seconds
 		EstimatedDuration *int64     `json:"estimatedDuration,omitempty"` // In Seconds
 		StartedAt         *time.Time `json:"startedAt,omitempty"`
 		FinishedAt        *time.Time `json:"finishedAt,omitempty"`
+	}
+
+	TileMergeRequest struct {
+		ID    int    `json:"id"`
+		Title string `json:"title,omitempty"`
 	}
 )
 

--- a/monitorables/github/api/delivery/http/handlers.go
+++ b/monitorables/github/api/delivery/http/handlers.go
@@ -47,3 +47,18 @@ func (h *GithubDelivery) GetChecks(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, tile)
 }
+
+func (h *GithubDelivery) GetPullRequest(c echo.Context) error {
+	// Bind / check Params
+	params := &models.PullRequestParams{}
+	if err := delivery.BindAndValidateParams(c, params); err != nil {
+		return err
+	}
+
+	tile, err := h.githubUsecase.PullRequest(params)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, tile)
+}

--- a/monitorables/github/api/mocks/Repository.go
+++ b/monitorables/github/api/mocks/Repository.go
@@ -79,6 +79,29 @@ func (_m *Repository) GetCount(query string) (int, error) {
 	return r0, r1
 }
 
+// GetPullRequest provides a mock function with given fields: owner, repository, id
+func (_m *Repository) GetPullRequest(owner string, repository string, id int) (*models.PullRequest, error) {
+	ret := _m.Called(owner, repository, id)
+
+	var r0 *models.PullRequest
+	if rf, ok := ret.Get(0).(func(string, string, int) *models.PullRequest); ok {
+		r0 = rf(owner, repository, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.PullRequest)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, int) error); ok {
+		r1 = rf(owner, repository, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetPullRequests provides a mock function with given fields: owner, repository
 func (_m *Repository) GetPullRequests(owner string, repository string) ([]models.PullRequest, error) {
 	ret := _m.Called(owner, repository)

--- a/monitorables/github/api/mocks/Usecase.go
+++ b/monitorables/github/api/mocks/Usecase.go
@@ -62,6 +62,29 @@ func (_m *Usecase) Count(params *models.CountParams) (*monitorormodels.Tile, err
 	return r0, r1
 }
 
+// PullRequest provides a mock function with given fields: params
+func (_m *Usecase) PullRequest(params *models.PullRequestParams) (*monitorormodels.Tile, error) {
+	ret := _m.Called(params)
+
+	var r0 *monitorormodels.Tile
+	if rf, ok := ret.Get(0).(func(*models.PullRequestParams) *monitorormodels.Tile); ok {
+		r0 = rf(params)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*monitorormodels.Tile)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*models.PullRequestParams) error); ok {
+		r1 = rf(params)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PullRequestsGenerator provides a mock function with given fields: params
 func (_m *Usecase) PullRequestsGenerator(params interface{}) ([]configmodels.GeneratedTile, error) {
 	ret := _m.Called(params)

--- a/monitorables/github/api/models/checksparams_test.go
+++ b/monitorables/github/api/models/checksparams_test.go
@@ -23,7 +23,7 @@ func TestChecksParams_Validate(t *testing.T) {
 	test.AssertParams(t, param, 3)
 }
 
-func TestBuildParams_String(t *testing.T) {
+func TestChecksParams_String(t *testing.T) {
 	param := &ChecksParams{Owner: "test", Repository: "test", Ref: "master"}
 	assert.Equal(t, "CHECKS-test-test-master", fmt.Sprint(param))
 }

--- a/monitorables/github/api/models/pullrequest.go
+++ b/monitorables/github/api/models/pullrequest.go
@@ -1,8 +1,16 @@
 package models
 
+import (
+	coreModels "github.com/monitoror/monitoror/models"
+)
+
 type PullRequest struct {
-	ID         int
+	ID     int
+	Title  string
+	Author coreModels.Author
+
 	Owner      string
 	Repository string
-	Ref        string
+	Branch     string
+	CommitSHA  string
 }

--- a/monitorables/github/api/models/pullrequestparams.go
+++ b/monitorables/github/api/models/pullrequestparams.go
@@ -1,0 +1,24 @@
+//+build !faker
+
+package models
+
+import (
+	"fmt"
+
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/params"
+)
+
+type (
+	PullRequestParams struct {
+		params.Default
+
+		Owner      string `json:"owner" query:"owner" validate:"required"`
+		Repository string `json:"repository" query:"repository" validate:"required"`
+		ID         *int   `json:"id" query:"id" validate:"required"`
+	}
+)
+
+// Used by cache as identifier
+func (p *PullRequestParams) String() string {
+	return fmt.Sprintf("PULLREQUEST-%s-%s-%d", p.Owner, p.Repository, *p.ID)
+}

--- a/monitorables/github/api/models/pullrequestparams_faker.go
+++ b/monitorables/github/api/models/pullrequestparams_faker.go
@@ -1,0 +1,40 @@
+//+build faker
+
+package models
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/params"
+	coreModels "github.com/monitoror/monitoror/models"
+)
+
+type (
+	PullRequestParams struct {
+		params.Default
+
+		Owner      string `json:"owner" query:"owner" validate:"required"`
+		Repository string `json:"repository" query:"repository" validate:"required"`
+		ID         *int   `json:"id" query:"id" validate:"required"`
+
+		Branch string `json:"branch" query:"branch"`
+
+		AuthorName      string `json:"authorName" query:"authorName"`
+		AuthorAvatarURL string `json:"authorAvatarURL" query:"authorAvatarURL"`
+
+		MergeRequestTitle string `json:"mergeRequestTitle" query:"mergeRequestTitle"`
+
+		Status            coreModels.TileStatus `json:"status" query:"status"`
+		PreviousStatus    coreModels.TileStatus `json:"previousStatus" query:"previousStatus"`
+		StartedAt         time.Time             `json:"startedAt" query:"startedAt"`
+		FinishedAt        time.Time             `json:"finishedAt" query:"finishedAt"`
+		Duration          int64                 `json:"duration" query:"duration"`
+		EstimatedDuration int64                 `json:"estimatedDuration" query:"estimatedDuration"`
+	}
+)
+
+// Used by cache as identifier
+func (p *PullRequestParams) String() string {
+	return fmt.Sprintf("PULLREQUEST-%s-%s-%d", p.Owner, p.Repository, p.ID)
+}

--- a/monitorables/github/api/models/pullrequestparams_test.go
+++ b/monitorables/github/api/models/pullrequestparams_test.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/AlekSi/pointer"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/test"
+)
+
+func TestPullRequest_Validate(t *testing.T) {
+	param := &PullRequestParams{Owner: "test", Repository: "test", ID: pointer.ToInt(10)}
+	test.AssertParams(t, param, 0)
+
+	param = &PullRequestParams{Owner: "test", Repository: "test"}
+	test.AssertParams(t, param, 1)
+
+	param = &PullRequestParams{Owner: "test"}
+	test.AssertParams(t, param, 2)
+
+	param = &PullRequestParams{}
+	test.AssertParams(t, param, 3)
+}
+
+func TestPullRequestParams_String(t *testing.T) {
+	param := &PullRequestParams{Owner: "test", Repository: "test", ID: pointer.ToInt(10)}
+	assert.Equal(t, "PULLREQUEST-test-test-10", fmt.Sprint(param))
+}

--- a/monitorables/github/api/repository.go
+++ b/monitorables/github/api/repository.go
@@ -8,6 +8,7 @@ type (
 	Repository interface {
 		GetCount(query string) (int, error)
 		GetChecks(owner, repository, ref string) (*models.Checks, error)
+		GetPullRequest(owner, repository string, id int) (*models.PullRequest, error)
 		GetPullRequests(owner, repository string) ([]models.PullRequest, error)
 		GetCommit(owner, repository, sha string) (*models.Commit, error)
 	}

--- a/monitorables/github/api/repository/api.go
+++ b/monitorables/github/api/repository/api.go
@@ -132,6 +132,15 @@ func (gr *githubRepository) GetChecks(owner, repository, ref string) (*models.Ch
 	return checks, nil
 }
 
+func (gr *githubRepository) GetPullRequest(owner, repository string, id int) (*models.PullRequest, error) {
+	pullRequest, _, err := gr.pullRequestService.Get(context.TODO(), owner, repository, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return fillPullRequest(pullRequest), nil
+}
+
 func (gr *githubRepository) GetPullRequests(owner, repository string) ([]models.PullRequest, error) {
 	pullRequests, _, err := gr.pullRequestService.List(context.TODO(), owner, repository, nil)
 	if err != nil {
@@ -140,17 +149,25 @@ func (gr *githubRepository) GetPullRequests(owner, repository string) ([]models.
 
 	var result []models.PullRequest
 	for _, pullRequest := range pullRequests {
-		pr := models.PullRequest{
-			ID:         pullRequest.GetNumber(),
-			Owner:      owner,
-			Repository: repository,
-			Ref:        pullRequest.Head.GetRef(),
-		}
-
-		result = append(result, pr)
+		result = append(result, *fillPullRequest(pullRequest))
 	}
 
 	return result, nil
+}
+
+func fillPullRequest(pr *githubApi.PullRequest) *models.PullRequest {
+	return &models.PullRequest{
+		ID:    pr.GetNumber(),
+		Title: pr.GetTitle(),
+		Author: coreModels.Author{
+			Name:      pr.GetUser().GetLogin(),
+			AvatarURL: pr.GetUser().GetAvatarURL(),
+		},
+		Owner:      pr.GetHead().GetUser().GetLogin(),
+		Repository: pr.GetHead().GetRepo().GetName(),
+		Branch:     pr.GetHead().GetRef(),
+		CommitSHA:  pr.GetHead().GetSHA(),
+	}
 }
 
 func (gr *githubRepository) GetCommit(owner, repository, sha string) (*models.Commit, error) {
@@ -162,7 +179,7 @@ func (gr *githubRepository) GetCommit(owner, repository, sha string) (*models.Co
 	result := &models.Commit{
 		SHA: sha,
 		Author: &coreModels.Author{
-			Name:      commit.Author.GetName(),
+			Name:      commit.Author.GetLogin(),
 			AvatarURL: gravatar.GetGravatarURL(commit.Author.GetEmail()),
 		},
 	}

--- a/monitorables/github/api/usecase.go
+++ b/monitorables/github/api/usecase.go
@@ -9,14 +9,16 @@ import (
 )
 
 const (
-	GithubCountTileType  coreModels.TileType = "GITHUB-COUNT"
-	GithubChecksTileType coreModels.TileType = "GITHUB-CHECKS"
+	GithubCountTileType       coreModels.TileType = "GITHUB-COUNT"
+	GithubChecksTileType      coreModels.TileType = "GITHUB-CHECKS"
+	GithubPullRequestTileType coreModels.TileType = "GITHUB-PULLREQUEST"
 )
 
 type (
 	Usecase interface {
 		Count(params *models.CountParams) (*coreModels.Tile, error)
 		Checks(params *models.ChecksParams) (*coreModels.Tile, error)
+		PullRequest(params *models.PullRequestParams) (*coreModels.Tile, error)
 
 		PullRequestsGenerator(params interface{}) ([]uiConfigModels.GeneratedTile, error)
 	}

--- a/monitorables/github/github_faker.go
+++ b/monitorables/github/github_faker.go
@@ -20,8 +20,9 @@ type Monitorable struct {
 	store *store.Store
 
 	// Config tile settings
-	countTileEnabler  registry.TileEnabler
-	checksTileEnabler registry.TileEnabler
+	countTileEnabler       registry.TileEnabler
+	checksTileEnabler      registry.TileEnabler
+	pullRequestTileEnabler registry.TileEnabler
 }
 
 func NewMonitorable(store *store.Store) *Monitorable {
@@ -31,6 +32,7 @@ func NewMonitorable(store *store.Store) *Monitorable {
 	// Register Monitorable Tile in config manager
 	m.countTileEnabler = store.Registry.RegisterTile(api.GithubCountTileType, versions.MinimalVersion, m.GetVariantsNames())
 	m.checksTileEnabler = store.Registry.RegisterTile(api.GithubChecksTileType, versions.MinimalVersion, m.GetVariantsNames())
+	m.pullRequestTileEnabler = store.Registry.RegisterTile(api.GithubPullRequestTileType, versions.MinimalVersion, m.GetVariantsNames())
 
 	return m
 }
@@ -47,8 +49,10 @@ func (m *Monitorable) Enable(variantName coreModels.VariantName) {
 	routeGroup := m.store.MonitorableRouter.Group("/github", variantName)
 	routeCount := routeGroup.GET("/count", delivery.GetCount)
 	routeChecks := routeGroup.GET("/checks", delivery.GetChecks)
+	routePullRequest := routeGroup.GET("/pullrequest", delivery.GetPullRequest)
 
 	// EnableTile data for config hydration
 	m.countTileEnabler.Enable(variantName, &githubModels.CountParams{}, routeCount.Path)
 	m.checksTileEnabler.Enable(variantName, &githubModels.ChecksParams{}, routeChecks.Path)
+	m.pullRequestTileEnabler.Enable(variantName, &githubModels.PullRequestParams{}, routePullRequest.Path)
 }

--- a/monitorables/github/github_test.go
+++ b/monitorables/github/github_test.go
@@ -44,6 +44,6 @@ func TestNewMonitorable(t *testing.T) {
 	}
 
 	// Test calls
-	mockMonitorableHelper.RouterAssertNumberOfCalls(t, 1, 2)
-	mockMonitorableHelper.TileSettingsManagerAssertNumberOfCalls(t, 2, 1, 2, 1)
+	mockMonitorableHelper.RouterAssertNumberOfCalls(t, 1, 3)
+	mockMonitorableHelper.TileSettingsManagerAssertNumberOfCalls(t, 3, 1, 3, 1)
 }

--- a/monitorables/register_test.go
+++ b/monitorables/register_test.go
@@ -34,7 +34,8 @@ func TestManager_RegisterMonitorables(t *testing.T) {
 	// ------------ GITHUB ------------
 	assert.NotNil(t, mr.TileMetadata[githubApi.GithubCountTileType])
 	assert.NotNil(t, mr.TileMetadata[githubApi.GithubChecksTileType])
-	assert.NotNil(t, mr.GeneratorMetadata[coreModels.NewGeneratorTileType(githubApi.GithubChecksTileType)])
+	assert.NotNil(t, mr.TileMetadata[githubApi.GithubPullRequestTileType])
+	assert.NotNil(t, mr.GeneratorMetadata[coreModels.NewGeneratorTileType(githubApi.GithubPullRequestTileType)])
 	// ------------ HTTP ------------
 	assert.NotNil(t, mr.TileMetadata[httpApi.HTTPStatusTileType])
 	assert.NotNil(t, mr.TileMetadata[httpApi.HTTPRawTileType])

--- a/pkg/gogithub/mocks/PullRequestService.go
+++ b/pkg/gogithub/mocks/PullRequestService.go
@@ -15,6 +15,38 @@ type PullRequestService struct {
 	mock.Mock
 }
 
+// Get provides a mock function with given fields: ctx, owner, repo, number
+func (_m *PullRequestService) Get(ctx context.Context, owner string, repo string, number int) (*github.PullRequest, *github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, number)
+
+	var r0 *github.PullRequest
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int) *github.PullRequest); ok {
+		r0 = rf(ctx, owner, repo, number)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.PullRequest)
+		}
+	}
+
+	var r1 *github.Response
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int) *github.Response); ok {
+		r1 = rf(ctx, owner, repo, number)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*github.Response)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, int) error); ok {
+		r2 = rf(ctx, owner, repo, number)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // List provides a mock function with given fields: ctx, owner, repo, opt
 func (_m *PullRequestService) List(ctx context.Context, owner string, repo string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
 	ret := _m.Called(ctx, owner, repo, opt)

--- a/pkg/gogithub/pullrequest.go
+++ b/pkg/gogithub/pullrequest.go
@@ -10,4 +10,5 @@ import (
 
 type PullRequestService interface {
 	List(ctx context.Context, owner string, repo string, opt *githubApi.PullRequestListOptions) ([]*githubApi.PullRequest, *githubApi.Response, error)
+	Get(ctx context.Context, owner string, repo string, number int) (*githubApi.PullRequest, *githubApi.Response, error)
 }

--- a/ui/src/classes/monitororTile.ts
+++ b/ui/src/classes/monitororTile.ts
@@ -7,6 +7,7 @@ import TileType from '@/enums/tileType'
 import TileAuthor from '@/interfaces/tileAuthor'
 import TileBuild from '@/interfaces/tileBuild'
 import TileConfig from '@/interfaces/tileConfig'
+import TileMergeRequest from '@/interfaces/tileMergeRequest'
 import TileState from '@/interfaces/tileState'
 
 export default abstract class AbstractMonitororTile extends Vue {
@@ -45,8 +46,25 @@ export default abstract class AbstractMonitororTile extends Vue {
     return this.$store.state.tilesState[this.stateKey]
   }
 
+  get mergeRequestLabelPrefix(): string | undefined {
+    if (this.mergeRequest === undefined) {
+      return
+    }
+
+    let mergeRequestPrefix = 'MR'
+    if (this.type === TileType.GitHubPullRequest) {
+      mergeRequestPrefix = 'PR'
+    }
+
+    return mergeRequestPrefix + '#' + this.mergeRequest.id
+  }
+
   get label(): string | undefined {
     if (this.config.label) {
+      if (this.config.label === '-') {
+        return
+      }
+
       return this.config.label
     }
 
@@ -71,6 +89,14 @@ export default abstract class AbstractMonitororTile extends Vue {
     }
 
     return this.build.branch
+  }
+
+  get mergeRequest(): TileMergeRequest | undefined {
+    if (this.build === undefined) {
+      return
+    }
+
+    return this.build.mergeRequest
   }
 
   get status(): string | undefined {

--- a/ui/src/components/SubTile.vue
+++ b/ui/src/components/SubTile.vue
@@ -2,6 +2,9 @@
   <div class="c-monitoror-sub-tile" :class="classes">
     <div class="c-monitoror-sub-tile--content">
       <div class="c-monitoror-sub-tile--label">
+        <template v-if="mergeRequestLabelPrefix">{{ mergeRequestLabelPrefix }}</template>
+        <template v-else-if="branch">{{ branch }}</template>
+        <template v-if="(mergeRequestLabelPrefix || branch) && label"> @ </template>
         {{ label }}
       </div>
 
@@ -53,24 +56,6 @@
         'c-monitoror-sub-tile__status-canceled': this.status === TileStatus.Canceled,
         'c-monitoror-sub-tile__status-action-required': this.status === TileStatus.ActionRequired,
       }
-    }
-
-    get label(): string | undefined {
-      if (this.config.label) {
-        return this.config.label
-      }
-
-      if (this.state === undefined) {
-        return
-      }
-
-      let label = this.state.label
-
-      if (this.branch !== undefined) {
-        label = `${this.branch} @ ${label}`
-      }
-
-      return label
     }
 
     get progressTime(): string | undefined {

--- a/ui/src/components/Tile.vue
+++ b/ui/src/components/Tile.vue
@@ -2,19 +2,24 @@
   <div class="c-monitoror-tile" :class="classes" :style="styles">
     <div class="c-monitoror-tile--content" v-if="!isEmpty">
       <div class="c-monitoror-tile--label">
+        <template v-if="mergeRequestLabelPrefix">{{ mergeRequestLabelPrefix }}</template>
+        <template v-if="mergeRequestLabelPrefix && label"> @</template>
         {{ label }}
       </div>
 
       <div class="c-monitoror-tile--build-info" v-if="branch || buildId">
         <template v-if="branch">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 1024">
-            <path
-              fill="currentColor"
-              d="M512 192c-70.625 0-128 57.344-128 128 0 47.219 25.875 88.062 64 110.281V448s0 128-128 128c-53.062 0-94.656 11.375-128 28.812V302.281c38.156-22.219 64-63.062 64-110.281 0-70.656-57.344-128-128-128S0 121.344 0 192c0 47.219 25.844 88.062 64 110.281V721.75C25.844 743.938 0 784.75 0 832c0 70.625 57.344 128 128 128s128-57.375 128-128c0-33.5-13.188-63.75-34.25-86.625C240.375 722.5 270.656 704 320 704c254 0 256-256 256-256v-17.719c38.125-22.219 64-63.062 64-110.281 0-70.656-57.375-128-128-128zm-384-64c35.406 0 64 28.594 64 64s-28.594 64-64 64-64-28.594-64-64 28.594-64 64-64zm0 768c-35.406 0-64-28.625-64-64 0-35.312 28.594-64 64-64s64 28.688 64 64c0 35.375-28.594 64-64 64zm384-512c-35.375 0-64-28.594-64-64s28.625-64 64-64 64 28.594 64 64-28.625 64-64 64z"/>
+          <svg v-if="mergeRequest" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+            <!-- Merge request icon -->
+            <path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/>
+          </svg>
+          <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+            <!-- Branch icon -->
+            <path fill-rule="evenodd" d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6A2.5 2.5 0 0110 8.5H6a1 1 0 00-1 1v1.128a2.251 2.251 0 11-1.5 0V5.372a2.25 2.25 0 111.5 0v1.836A2.492 2.492 0 016 7h4a1 1 0 001-1v-.628A2.25 2.25 0 019.5 3.25zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zM3.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"/>
           </svg>
           {{ branch }}
         </template>
-        <template v-if="branch && buildId">—</template>
+        <template v-if="branch && buildId"> —</template>
         <template v-if="buildId">
           #{{ buildId }}
         </template>
@@ -295,10 +300,10 @@
 
   .c-monitoror-tile--build-info svg {
     display: inline-block;
-    width: 16px;
+    width: 18px;
     vertical-align: middle;
-    transform: translate(2px, -1px);
-    margin-right: -5px;
+    transform: translate(1px, 0px);
+    margin-right: -7px;
   }
 
   .c-monitoror-tile--value {

--- a/ui/src/components/TileIcon.vue
+++ b/ui/src/components/TileIcon.vue
@@ -99,6 +99,7 @@
     get isGitHub(): boolean {
       return [
         TileType.GitHubChecks,
+        TileType.GitHubPullRequest,
         TileType.GitHubCount,
       ].includes(this.tileType)
     }

--- a/ui/src/enums/tileType.ts
+++ b/ui/src/enums/tileType.ts
@@ -6,6 +6,7 @@ export enum TileType {
   Port = 'PORT',
   Pingdom = 'PINGDOM-CHECK',
   GitHubChecks = 'GITHUB-CHECKS',
+  GitHubPullRequest = 'GITHUB-PULLREQUEST',
   GitHubCount = 'GITHUB-COUNT',
   GitLab = 'GITLAB-BUILD',
   Travis = 'TRAVISCI-BUILD',

--- a/ui/src/interfaces/tileBuild.ts
+++ b/ui/src/interfaces/tileBuild.ts
@@ -1,10 +1,12 @@
 import TileStatus from '@/enums/tileStatus'
 import TileAuthor from '@/interfaces/tileAuthor'
+import TileMergeRequest from '@/interfaces/tileMergeRequest'
 
 export default interface TileBuild {
   previousStatus?: TileStatus,
   id?: string,
   branch?: string,
+  mergeRequest?: TileMergeRequest,
   author?: TileAuthor,
   estimatedDuration?: number,
   startedAt?: number,

--- a/ui/src/interfaces/tileMergeRequest.ts
+++ b/ui/src/interfaces/tileMergeRequest.ts
@@ -1,0 +1,6 @@
+export interface TileMergeRequest {
+  id: number,
+  title: string,
+}
+
+export default TileMergeRequest


### PR DESCRIPTION
- Adding new `GITHUB_PULLREQUEST` type to handle pullrequest properly. (Probably never used directly)
- Adding "mergeRequest" into tile.build structure
```go
	TileMergeRequest struct {
		ID    int    `json:"id"`
		Title string `json:"title,omitempty"`
	}
```
- Rename `GENERATE:GITHUB_CHECKS` into `GENERATE:GITHUB_PULLREQUEST`
- fix #309