### PR TITLE
docs(guide): use MO_DISABLEUI in dev guide

### DIFF
--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -257,6 +257,7 @@ go get -u github.com/GeertJohan/go.rice/rice
       <pre class="language-bash"><code>
 # Core
 make install
+# Optionaly run with UI by prepending the command with MO_DISABLEUI=false
 make run
       </code></pre>
       <pre class="language-bash"><code>


### PR DESCRIPTION
Documented `MO_DISABLEUI` for the development guide to running core.

Fixes #331