### PR TITLE
fix(core/gitlab): add test in case of running build without startingAt

### DIFF
--- a/monitorables/gitlab/api/usecase/gitlab.go
+++ b/monitorables/gitlab/api/usecase/gitlab.go
@@ -182,7 +182,10 @@ func (gu *gitlabUsecase) computePipeline(params interface{}, tile *coreModels.Ti
 
 	// Duration
 	if tile.Status == coreModels.RunningStatus {
-		tile.Build.Duration = pointer.ToInt64(int64(time.Since(*tile.Build.StartedAt).Seconds()))
+		// In case of build without StartedAt ...
+		if tile.Build.StartedAt != nil {
+			tile.Build.Duration = pointer.ToInt64(int64(time.Since(*tile.Build.StartedAt).Seconds()))
+		}
 
 		estimatedDuration := gu.buildsCache.GetEstimatedDuration(params)
 		if estimatedDuration != nil {


### PR DESCRIPTION
Sometimes, gitlab drop startedAt value from running pipeline ...
Can't reproduce this issue, so i just add fix to avoid crash