### PR TITLE
feat(http): Handle client certificate for http ping

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -1457,6 +1457,18 @@ MO_MONITORABLE_GITLAB_TIMEOUT=5000
           Check if SSL certificate is valid <br>
           <span class="tag">Default:</span> <code>true</code>
         </dd>
+
+        <dt><code>MO_MONITORABLE_HTTP_CERTIFICATE</code> <code class="type">string</code></dt>
+        <dd>
+          Client certificate file path to use when making http calls <br>
+          <span class="tag">Optional</span> <code></code>
+        </dd>
+
+        <dt><code>MO_MONITORABLE_HTTP_KEY</code> <code class="type">string</code></dt>
+        <dd>
+          Key file path for the client certificate provided <br>
+          <span class="tag">Optional</span> <code></code>
+        </dd>
       </dl>
 
       <p class="success-block">

--- a/monitorables/http/api/repository/http.go
+++ b/monitorables/http/api/repository/http.go
@@ -18,8 +18,18 @@ type (
 )
 
 func NewHTTPRepository(config *config.HTTP) api.Repository {
+	var certificates []tls.Certificate
+
+	if config.Certificate != "" && config.Key != "" {
+		cert, error := tls.LoadX509KeyPair(config.Certificate, config.Key)
+
+		if error == nil {
+			certificates = append(certificates, cert)
+		}
+	}
+
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !config.SSLVerify},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !config.SSLVerify, Certificates: certificates},
 	}
 	client := &http.Client{Transport: tr, Timeout: time.Duration(config.Timeout) * time.Millisecond}
 

--- a/monitorables/http/config/config.go
+++ b/monitorables/http/config/config.go
@@ -2,8 +2,10 @@ package config
 
 type (
 	HTTP struct {
-		Timeout   int `validate:"gte=0"` // In Millisecond
-		SSLVerify bool
+		Timeout     int `validate:"gte=0"` // In Millisecond
+		SSLVerify   bool
+		Certificate string
+		Key         string
 	}
 )
 


### PR DESCRIPTION
Certificate and key files can be specified using env variables MO_MONITORABLE_HTTP_CERTIFICATE and MO_MONITORABLE_HTTP_KEY.

Client Certificate used is global to all domains.

Fixes #390 