### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -75,7 +75,7 @@ jobs:
         id: init
         run: |
           VERSION=$(cat VERSION)
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -75,7 +75,7 @@ jobs:
         id: init
         run: |
           VERSION=$(cat VERSION)
-          echo ::set-output name=VERSION::$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,8 +147,8 @@ jobs:
         id: init
         run: |
           VERSION=$(cat VERSION)
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "UPLOAD_URL=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/$VERSION --silent | grep -Po '"upload_url"\s*:\s*"[^"]+' | cut -d'"' -f4)" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "UPLOAD_URL=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/$VERSION --silent | grep -Po '"upload_url"\s*:\s*"[^"]+' | cut -d'"' -f4)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v1
         with:
@@ -204,9 +204,9 @@ jobs:
         id: init
         run: |
           VERSION=$(cat VERSION)
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "MINOR_VERSION=$(echo $VERSION | cut -d "." -f 1,2)" >> $GITHUB_OUTPUT
-          echo "MAJOR_VERSION=$(echo $VERSION | cut -d "." -f 1)" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "MINOR_VERSION=$(echo $VERSION | cut -d "." -f 1,2)" >> "$GITHUB_OUTPUT"
+          echo "MAJOR_VERSION=$(echo $VERSION | cut -d "." -f 1)" >> "$GITHUB_OUTPUT"
 
 
       - uses: actions/download-artifact@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -147,8 +147,8 @@ jobs:
         id: init
         run: |
           VERSION=$(cat VERSION)
-          echo ::set-output name=VERSION::$VERSION
-          echo ::set-output name=UPLOAD_URL::$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/$VERSION --silent | grep -Po '"upload_url"\s*:\s*"[^"]+' | cut -d'"' -f4)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "UPLOAD_URL=$(curl https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/$VERSION --silent | grep -Po '"upload_url"\s*:\s*"[^"]+' | cut -d'"' -f4)" >> $GITHUB_OUTPUT
 
       - uses: actions/download-artifact@v1
         with:
@@ -204,9 +204,9 @@ jobs:
         id: init
         run: |
           VERSION=$(cat VERSION)
-          echo ::set-output name=VERSION::$VERSION
-          echo ::set-output name=MINOR_VERSION::$(echo $VERSION | cut -d "." -f 1,2)
-          echo ::set-output name=MAJOR_VERSION::$(echo $VERSION | cut -d "." -f 1)
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "MINOR_VERSION=$(echo $VERSION | cut -d "." -f 1,2)" >> $GITHUB_OUTPUT
+          echo "MAJOR_VERSION=$(echo $VERSION | cut -d "." -f 1)" >> $GITHUB_OUTPUT
 
 
       - uses: actions/download-artifact@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


