### PR TITLE
feat(http): Add support for custom HTTP headers (via env variable) and set default User-Agent

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -1469,6 +1469,12 @@ MO_MONITORABLE_GITLAB_TIMEOUT=5000
           Key file path for the client certificate provided <br>
           <span class="tag">Optional</span> <code></code>
         </dd>
+
+        <dt><code>MO_MONITORABLE_HTTP_HEADERS</code> <code class="type">string</code></dt>
+        <dd>
+          Add HTTP headers separated by comma <br>
+          <span class="tag">Default:</span> <code>User-Agent: Monitoror</code>
+        </dd>
       </dl>
 
       <p class="success-block">
@@ -1481,6 +1487,7 @@ MO_MONITORABLE_GITLAB_TIMEOUT=5000
       <pre class="example"><code>
 MO_MONITORABLE_HTTP_TIMEOUT=1000
 MO_MONITORABLE_HTTP_SSLVERIFY=true
+MO_MONITORABLE_HTTP_HEADERS="User-Agent: My-Agent,X-Custom-Header: Value"
       </code></pre>
 
       <h4 id="tile-http-status">HTTP-STATUS</h4>

--- a/monitorables/http/api/repository/http.go
+++ b/monitorables/http/api/repository/http.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/monitoror/monitoror/monitorables/http/api"
@@ -14,6 +15,10 @@ import (
 type (
 	httpRepository struct {
 		httpClient *http.Client
+	}
+	clientInterceptor struct {
+		Transport http.RoundTripper // A custom RoundTripper that adds headers to each request.
+		Headers   []string
 	}
 )
 
@@ -28,9 +33,13 @@ func NewHTTPRepository(config *config.HTTP) api.Repository {
 		}
 	}
 
-	tr := &http.Transport{
+	bt := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: !config.SSLVerify, Certificates: certificates},
 	}
+
+	// Intercept and add headers
+	tr := &clientInterceptor{bt, config.Headers}
+
 	client := &http.Client{Transport: tr, Timeout: time.Duration(config.Timeout) * time.Millisecond}
 
 	return &httpRepository{client}
@@ -54,4 +63,25 @@ func (r *httpRepository) Get(url string) (response *models.Response, err error) 
 	}
 
 	return
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+//
+// It adds the headers from Headers to the request, then calls the original
+// RoundTripper to make the request.
+func (ci *clientInterceptor) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	headers := append(config.Default.Headers, ci.Headers...)
+
+	// Add headers to the request
+	for _, header := range headers {
+
+		parts := strings.SplitN(header, ":", 2)
+		if len(parts) == 2 {
+			req.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+		}
+	}
+
+	// Call the original RoundTripper
+	return ci.Transport.RoundTrip(req)
 }

--- a/monitorables/http/config/config.go
+++ b/monitorables/http/config/config.go
@@ -6,10 +6,12 @@ type (
 		SSLVerify   bool
 		Certificate string
 		Key         string
+		Headers     []string
 	}
 )
 
 var Default = &HTTP{
 	Timeout:   2000,
 	SSLVerify: true,
+	Headers:   []string{"User-Agent: Monitoror"},
 }


### PR DESCRIPTION
Changes

This PR introduces the MO_MONITORABLE_HTTP_HEADERS environment variable, allowing users to add custom HTTP headers. Additionally, it sets the User-Agent header to "Monitoror" by default.

Fixes

Fixes #426 Cannot customize HTTP headers and missing User-Agent header

Changes Summary

1. Added MO_MONITORABLE_HTTP_HEADERS environment variable for custom HTTP headers
2. Set default User-Agent header to "Monitoror"